### PR TITLE
feature/prevent-duplicate-stamps

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,13 +87,11 @@ func main() {
 						user := event.User         // ユーザーID
 
 						userInfo, err := api.GetUserInfo(user) // ユーザー情報の取得
-
 						if err != nil {
 							log.Println(err)
 						}
 
 						snapshot, firestoreErr := client.Collection("users").Doc(userInfo.ID).Get(ctx)
-
 						if firestoreErr != nil {
 							fmt.Println("Failed adding alovelace:", firestoreErr)
 						}
@@ -103,14 +101,22 @@ func main() {
 							getUserFromFirestore := snapshot.Data()
 
 							if res, state := getUserFromFirestore["technology"].([]interface{}); state {
+								for _, v := range res {
+									if v == reaction {
+										fmt.Println("スタンプが重複しているよ")
+										return
+									}
+								}
+
 								technology := append(res, reaction)
 
 								client.Collection("users").Doc(userInfo.ID).Set(ctx, map[string]interface{} {
 									"technology": technology,
 								}, firestore.MergeAll)
 							}
+
 							fmt.Println("データあるルート")
-							break
+							return
 						}
 
 						var initialTechnology []string
@@ -125,7 +131,7 @@ func main() {
 							"technology": technology,
 						})
 
-						if(err != nil) {
+						if err != nil {
 							fmt.Println("Failed adding alovelace:", err)
 						}
 


### PR DESCRIPTION
## 【実装内容】
既に推されているスタンプを押した場合、Firestoreで保存するデータに重複が起きないようにしました

### ▼ こういう感じに重複しても…
<img width="469" alt="スクリーンショット 2021-11-07 11 04 29" src="https://user-images.githubusercontent.com/60911215/140629568-9fefa19c-acd0-473c-aad1-4bcca3175c6c.png">

<br>

### ▼ 保存される値は常に1つずつ！
<img width="372" alt="スクリーンショット 2021-11-07 11 04 45" src="https://user-images.githubusercontent.com/60911215/140629574-b0be93f4-d37b-4167-812d-43d0225522e7.png">


